### PR TITLE
Support lifetime params

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,9 @@ enum AllTuplesParam {
 impl Parse for AllTuplesParam {
     fn parse(input: ParseStream) -> Result<Self> {
         if let Ok(lifetime) = input.parse::<Lifetime>() {
-            return Ok(Self::Lifetime(lifetime));
+            Ok(Self::Lifetime(lifetime))
         } else {
-            return Ok(Self::Ident(input.parse()?));
+            Ok(Self::Ident(input.parse()?))
         }
     }
 }


### PR DESCRIPTION
# Objective

Allow the macro to be used with lifetime parameters

```rs
all_tuples!(impl_system_function, 0, 16, F, 'w, 's);
```

Also fixed a bug.

## Testing

- Tested with bevy use cases.
