### PR TITLE
fix(#37)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,11 @@ pub fn all_tuples_enumerated(input: TokenStream) -> TokenStream {
 /// // impl_wrapped_in_foo!(2, T0, T1);
 /// // ..
 /// // impl_wrapped_in_foo!(15, T0 .. T14);
+///
+/// all_tuples_with_size!(impl_wrapped_in_foo, 16, 20, T);
+/// // impl_wrapped_in_foo!(16, T0 .. T15);
+/// // ..
+/// // impl_wrapped_in_foo!(20, T0 .. T19);
 /// ```
 ///
 /// ## Multiple parameters
@@ -351,6 +356,11 @@ pub fn all_tuples_enumerated(input: TokenStream) -> TokenStream {
 /// // impl_append!(3, (P0, p0), (P1, p1), (P2, p2));
 /// // ..
 /// // impl_append!(15, (P0, p0) .. (P14, p14));
+///
+/// all_tuples_with_size!(impl_append, 16, 20, P, p);
+/// // impl_append!(16, (P0, p0) .. (P15, p15));
+/// // ..
+/// // impl_append!(20, (P0, p0) .. (P19, p19));
 /// ```
 ///
 /// **`#[doc(fake_variadic)]`**
@@ -390,8 +400,7 @@ pub fn all_tuples_enumerated(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn all_tuples_with_size(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as AllTuples);
-    let len = 1 + input.end - input.start;
-    let ident_tuples = (0..=len)
+    let ident_tuples = (0..input.end)
         .map(|i| {
             let idents = input
                 .idents


### PR DESCRIPTION
# Objective

fixes #37

## Solution
At first, I feel this part is strange:
```rust
    let len = 1 + input.end - input.start;
    let ident_tuples = (0..=len)
        .map(|i| {
            let idents = input
                .idents
                .iter()
                .map(|ident| format_ident!("{}{}", ident, i));
            to_ident_tuple_enumerated(idents, input.idents.len())
        })
        .collect::<Vec<_>>();
```
If end = 2, start = 0, then len = 3. But ident_tuples has 4 elements, while we only need 2.

I make changes to it first, and then #37 just fixed.

## Testing

- Did you test these changes? If so, how?
```sh
RUSTFLAGS="--cfg docsrs" cargo +nightly expand --example all_tuples
```
And got
```rust
#[allow(unused_variables)]
#[allow(non_snake_case)]
#[allow(clippy::unused_unit)]
impl Foo for () {
    const FOO_HARDER: bool = true;
    fn foo() -> bool {
        true
    }
}
#[allow(unused_variables)]
#[allow(non_snake_case)]
#[allow(clippy::unused_unit)]
#[doc(fake_variadic)]
///This trait is implemented for tuples down to 0 up to 15 items long.
impl<F: Foo> Foo for (F,) {
    const FOO_HARDER: bool = true && F::FOO_HARDER;
    fn foo() -> bool {
        true
    }
}
#[allow(unused_variables)]
#[allow(non_snake_case)]
#[allow(clippy::unused_unit)]
#[doc(hidden)]
impl<F0: Foo, F1: Foo> Foo for (F0, F1) {
    const FOO_HARDER: bool = true && F0::FOO_HARDER && F1::FOO_HARDER;
    fn foo() -> bool {
        true
    }
}
```
- Are there any parts that need more testing?
I open doc with this cmd
```sh
RUSTFLAGS="--cfg docsrs" cargo +nightly doc --open --example all_tuples
```
But the fake_variadics is not right. I believe it's due to I missed some flags and it'll be right when publishing onto cratesio.
However, I'm not very sure.

- How can other people (reviewers) test your changes? Is there anything specific they need to know?
Use correct command to check `cargo doc` result
Mine is incorrect:
```sh
RUSTFLAGS="--cfg docsrs" cargo +nightly doc --open --example all_tuples
```

By the way,

- I change `doc_auto_cfg` to `doc_cfg`, since they are merged since Rust nightly 1.92. And docs.rs uses nightly Rust. Anyway, this crate has no features gate, there's no effect I think.
