### PR TITLE
chore: make the document of the example able to be previewed

### DIFF
--- a/documentation/debugging.md
+++ b/documentation/debugging.md
@@ -6,3 +6,9 @@
   - Alternatively you could install and use [cargo expand](https://github.com/dtolnay/cargo-expand) which adds syntax highlighting to the terminal output.
     - Additionally get pager by piping to `less` ( on Unix systems ): `cargo expand --color always | less -R`
 - Print output during macro compilation using `eprintln!("hi");`
+
+## Preview Doc
+
+```sh
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --example all_tuples --no-deps --open
+```

--- a/examples/demonstrations/all_tuples.rs
+++ b/examples/demonstrations/all_tuples.rs
@@ -1,5 +1,7 @@
 //! An example of using `all_tuples!`
 
+#![cfg_attr(any(docsrs), feature(rustdoc_internals))]
+
 use variadics_please::all_tuples;
 
 fn main() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,6 @@ impl Parse for AllTuples {
 ///
 /// ```
 /// // `rustdoc_internals` is needed for `#[doc(fake_variadics)]`
-/// #![allow(internal_features)]
 /// #![cfg_attr(any(docsrs, docsrs_dep), feature(rustdoc_internals))]
 /// ```
 ///
@@ -377,7 +376,6 @@ pub fn all_tuples_enumerated(input: TokenStream) -> TokenStream {
 ///
 /// ```
 /// // `rustdoc_internals` is needed for `#[doc(fake_variadics)]`
-/// #![allow(internal_features)]
 /// #![cfg_attr(any(docsrs, docsrs_dep), feature(rustdoc_internals))]
 /// ```
 ///


### PR DESCRIPTION
# Objective

We can only preview the output with things like `cargo expand`. In this PR, I add some lines about previewing documentation with `cargo doc --open`.

## Solution

- Turn on a necessary feature gate in `all_tuples` example.
- Add annotation in `debugging.md`

## Testing

The result of following cmd is almost the same as docs.rs
```sh
RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --example all_tuples --no-deps --open
```
